### PR TITLE
Replace BlingFire fork with microsoft repo (v1)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "blingfire-sys/BlingFire"]
 	path = blingfire-sys/BlingFire
-	url = https://github.com/reinfer/BlingFire.git
+	url = https://github.com/microsoft/BlingFire.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,3 @@ language: rust
 
 rust:
   - stable
-  - beta
-  - nightly
-

--- a/blingfire-sys/Cargo.toml
+++ b/blingfire-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blingfire-sys"
-version = "0.2.1"
+version = "1.0.0"
 authors = ["reinfer Ltd. <eng@reinfer.io>"]
 edition = "2018"
 description = "Bindings to the BlingFire C++ library"
@@ -17,7 +17,5 @@ license = "MIT"
 build = "build.rs"
 links = "blingfiretokdll"
 
-[dependencies]
-
 [build-dependencies]
-cmake = "0.1.40"
+cmake = "0.1.44"

--- a/blingfire/Cargo.toml
+++ b/blingfire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blingfire"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["reinfer Ltd. <eng@reinfer.io>"]
 edition = "2018"
 description = "Wrapper for the BlingFire tokenization library"
@@ -16,8 +16,8 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-blingfire-sys = { path = "../blingfire-sys", version = "0.2.1" }
-snafu = "0.4.3"
+blingfire-sys = { path = "../blingfire-sys", version = "1.0.0" }
+snafu = "0.6.8"
 
 [build-dependencies]
 skeptic = "0.13.4"


### PR DESCRIPTION
Previously, this wrapper depended on a fork configured to enable static
linking. This feature has been merged into the main repo.