### PR TITLE
Update dependencies and fix cmake compatibility

### DIFF
--- a/blingfire-sys/Cargo.toml
+++ b/blingfire-sys/Cargo.toml
@@ -27,4 +27,4 @@ exclude = [
 ]
 
 [build-dependencies]
-cmake = "0.1.44"
+cmake = "0.1.57"

--- a/blingfire-sys/build.rs
+++ b/blingfire-sys/build.rs
@@ -5,6 +5,7 @@ fn main() {
         .always_configure(true)
         .define("BLING_FIRE_VERSION_MAJOR", "1")
         .define("BLING_FIRE_VERSION_MINOR", "0")
+        .define("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
         .build_target("blingfiretokdll_static")
         .build();
 

--- a/blingfire/Cargo.toml
+++ b/blingfire/Cargo.toml
@@ -16,4 +16,4 @@ license = "MIT"
 
 [dependencies]
 blingfire-sys = { path = "../blingfire-sys", version = "1.0.1" }
-snafu = "0.6.8"
+snafu = "0.8.9"

--- a/blingfire/src/errors.rs
+++ b/blingfire/src/errors.rs
@@ -3,7 +3,7 @@ use std::result::Result as StdResult;
 
 /// Error enum encoding tokenization errors.
 #[derive(Debug, Snafu, PartialEq)]
-#[snafu(visibility = "pub")]
+#[snafu(visibility(pub))]
 pub enum Error {
     /// Source buffer is too large (capacity > MAX_TEXT_LENGTH).
     #[snafu(display("Source buffer is too large (capacity > {}).", max_text_length))]
@@ -13,7 +13,7 @@ pub enum Error {
     #[snafu(display(
         "An unknown error caused the tokenizer to fail (the C++ function returned -1)."
     ))]
-    UnknownError,
+    Unknown,
 }
 
 /// Result of calling the tokenizer functions.

--- a/blingfire/src/lib.rs
+++ b/blingfire/src/lib.rs
@@ -85,7 +85,7 @@ where
     let source_len = source.len();
     ensure!(
         source_len <= MAX_TEXT_LENGTH,
-        errors::SourceTooLarge {
+        errors::SourceTooLargeSnafu {
             max_text_length: MAX_TEXT_LENGTH
         }
     );
@@ -102,7 +102,7 @@ where
         };
 
         // The C++ function returned -1, an unknown error.
-        ensure!(length > 0, errors::UnknownError);
+        ensure!(length > 0, errors::UnknownSnafu);
 
         if length as usize > destination.capacity() {
             // There was not enough capacity in `destination` to store the parsed text.
@@ -180,7 +180,7 @@ mod tests {
         assert!(
             result.is_err()
                 && result.unwrap_err()
-                    == Error::SourceTooLarge {
+                    == Error::SourceTooLargeSnafu {
                         max_text_length: MAX_TEXT_LENGTH
                     }
         );


### PR DESCRIPTION
This PR brings things up to date: adds compatibility with latest versions of snafu and cmake crates, updates to latest version of blingfire, fixes problems with modern versions of CMake