### PR TITLE
chore(build): support macOS build (link libc++, set CMake policy floor)

### DIFF
--- a/blingfire-sys/build.rs
+++ b/blingfire-sys/build.rs
@@ -1,7 +1,14 @@
 use cmake::Config;
 
 fn main() {
-    let destination = Config::new("BlingFire")
+    let is_macos = std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos");
+
+    let mut config = Config::new("BlingFire");
+    if is_macos {
+        // Modern CMake dropped support for BlingFire's pre-3.5 cmake_minimum_required.
+        config.define("CMAKE_POLICY_VERSION_MINIMUM", "3.5");
+    }
+    let destination = config
         .always_configure(true)
         .define("BLING_FIRE_VERSION_MAJOR", "1")
         .define("BLING_FIRE_VERSION_MINOR", "0")
@@ -14,5 +21,7 @@ fn main() {
     );
     println!("cargo:rustc-link-lib=static=blingfiretokdll_static");
     println!("cargo:rustc-link-lib=static=fsaClient");
-    println!("cargo:rustc-link-lib=stdc++");
+    // macOS ships libc++, not libstdc++; Linux keeps stdc++ unchanged.
+    let cxx = if is_macos { "c++" } else { "stdc++" };
+    println!("cargo:rustc-link-lib={cxx}");
 }


### PR DESCRIPTION
## What

Make `blingfire-sys` build on macOS. All changes are `target_os`-gated, so **Linux builds are byte-identical** — this is additive macOS support only.

Two changes in `blingfire-sys/build.rs`:

- **Link `c++`, not `stdc++`, on macOS.** macOS ships libc++; `-lstdc++` doesn't exist there. Linux keeps `stdc++` unchanged.
- **Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` on macOS.** Modern CMake dropped support for the pre-3.5 `cmake_minimum_required` that BlingFire pins, so configure fails without a policy floor. Baked in via an explicit `.define` (no env mutation).

A third macOS-only failure — an empty `fsaCompile` archive tripping macOS `ar` — does **not** occur on a git checkout: the full `microsoft/BlingFire` submodule (169 `.cpp`) is present, so the archive is non-empty. (It only bites the published crate, which excludes `blingfirecompile.library`.) No CMakeLists or submodule edit needed.

## Verification

Built on macOS (M-series) with a clean env (`RUSTFLAGS` and `CMAKE_POLICY_VERSION_MINIMUM` both unset): `blingfire-sys` builds, the downstream `uipath_mls_sentence_ext` cdylib links, and tokenization tests pass.

## Why

Unblocks local ixp-platform builds on macOS without the `~/.cargo` cache hack. Once merged, ixp-platform will pin this via `[patch.crates-io] blingfire-sys = { git = ..., rev = ... }`.

Ref: RE-12549
